### PR TITLE
Fixed AnInterface.j so Implementor.j will work

### DIFF
--- a/examples/AnInterface.j
+++ b/examples/AnInterface.j
@@ -25,7 +25,7 @@
 ;
 ; declare abstract method foo() - note that the method body is empty.
 ;
-.method abstract foo()V
+.method public abstract foo()V
 .end method
 
 


### PR DESCRIPTION
When trying to run Implementor.class on JDK 8 I received this error.

jasmin (master ✘)✖✹✭ ᐅ  java examples.Implementor
Error: A JNI error has occurred, please check your installation and try again
Exception in thread "main" java.lang.ClassFormatError: Method foo in class examples/AnInterface has illegal modifiers: 0x400

I was able to fix it by performing this change.